### PR TITLE
fix _update_points

### DIFF
--- a/judge/admin.py
+++ b/judge/admin.py
@@ -256,13 +256,12 @@ class ProblemAdmin(VersionAdmin):
         with connection.cursor() as c:
             c.execute('''
                 UPDATE judge_profile prof INNER JOIN (
-                    SELECT prof.id AS id, MAX(sub.points) AS delta
-                    FROM judge_profile prof INNER JOIN
-                         judge_submission sub ON (sub.user_id = prof.id)
+                    SELECT sub.user_id, MAX(sub.points) AS delta
+                    FROM judge_submission sub
                     WHERE sub.problem_id = %s
-                    GROUP BY sub.problem_id
-                ) `data` ON (`data`.id = prof.id)
-                SET points = points {} delta
+                    GROUP BY sub.user_id
+                ) `data` ON (sub.user_id = prof.id)
+                SET prof.points = prof.points {} `data`.delta
             '''.format(sign), (problem_id,))
 
     def _update_points_many(self, ids, sign):


### PR DESCRIPTION
Using `WHERE sub.problem_id = %s` and `GROUP BY sub.problem_id` together doesn't make sense.
Submissions should be grouped by profile id so that it can properly get maximum points for each user.
Also, `joining inside joining` may not be necessary.