### PR TITLE
Fix transcription of `can_view`

### DIFF
--- a/judge/templatetags/submission.py
+++ b/judge/templatetags/submission.py
@@ -18,7 +18,7 @@ def submission_layout(context, submission, profile_id, user, editable_problem_id
         can_view = True
 
     if submission.problem_id in completed_problem_ids:
-        can_view = submission.problem.is_public or profile_id in submission.problem.tester_ids
+        can_view |= submission.problem.is_public or profile_id in submission.problem.tester_ids
 
     info_colspan = 1 if can_view else 2
     if submission.status != 'G':


### PR DESCRIPTION
https://github.com/DMOJ/site/commit/ad2793f42259ece56b2a8c0bbb12c98290673ca6 suggests that `can_view` is not wholly dependant on the status of `submission.problem.is_public or profile_id in submission.problem.tester_ids` if the problem is solved by the user in question.