### PR TITLE
Lower priority rejudges and judging priority system

### DIFF
--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -138,7 +138,7 @@ class SubmissionAdmin(admin.ModelAdmin):
             queryset = queryset.filter(Q(problem__authors__id=id) | Q(problem__curators__id=id))
         judged = len(queryset)
         for model in queryset:
-            model.judge(was_rejudged=True)
+            model.judge(rejudged=True)
         self.message_user(request, ungettext('%d submission were successfully scheduled for rejudging.',
                                              '%d submissions were successfully scheduled for rejudging.',
                                              judged) % judged)
@@ -229,7 +229,7 @@ class SubmissionAdmin(admin.ModelAdmin):
         if not request.user.has_perm('judge.edit_all_problem') and \
                 not submission.problem.is_editor(request.user.profile):
             raise PermissionDenied()
-        submission.judge(was_rejudged=True)
+        submission.judge(rejudged=True)
         return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
 
     def get_form(self, request, obj=None, **kwargs):

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -138,7 +138,7 @@ class SubmissionAdmin(admin.ModelAdmin):
             queryset = queryset.filter(Q(problem__authors__id=id) | Q(problem__curators__id=id))
         judged = len(queryset)
         for model in queryset:
-            model.judge(rejudged=True)
+            model.judge(rejudge=True)
         self.message_user(request, ungettext('%d submission were successfully scheduled for rejudging.',
                                              '%d submissions were successfully scheduled for rejudging.',
                                              judged) % judged)
@@ -229,7 +229,7 @@ class SubmissionAdmin(admin.ModelAdmin):
         if not request.user.has_perm('judge.edit_all_problem') and \
                 not submission.problem.is_editor(request.user.profile):
             raise PermissionDenied()
-        submission.judge(rejudged=True)
+        submission.judge(rejudge=True)
         return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
 
     def get_form(self, request, obj=None, **kwargs):

--- a/judge/judgeapi.py
+++ b/judge/judgeapi.py
@@ -39,11 +39,11 @@ def judge_request(packet, reply=True):
         return result
 
 
-def judge_submission(submission, **kwargs):
+def judge_submission(submission, rejudge):
     from .models import ContestSubmission, Submission, SubmissionTestCase
 
-    updates = {'time': None, 'memory': None, 'points': None, 'result': None, 'error': None}
-    updates.update(kwargs, status='QU')
+    updates = {'time': None, 'memory': None, 'points': None, 'result': None, 'error': None,
+               'was_rejudged': rejudge, 'status': 'QU'}
     try:
         # This is set proactively; it might get unset in judgecallback's on_grading_begin if the problem doesn't
         # actually have pretests stored on the judge.
@@ -72,6 +72,7 @@ def judge_submission(submission, **kwargs):
             'problem-id': submission.problem.code,
             'language': submission.language.key,
             'source': submission.source,
+            'priority': 1 if rejudge else 0,
         })
     except BaseException:
         logger.exception('Failed to send request to judge')

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -105,8 +105,8 @@ class Submission(models.Model):
     def long_status(self):
         return Submission.USER_DISPLAY_CODES.get(self.short_status, '')
 
-    def judge(self, **kwargs):
-        judge_submission(self, **kwargs)
+    def judge(self, rejudge, **kwargs):
+        judge_submission(self, rejudge, **kwargs)
 
     judge.alters_data = True
 

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -105,8 +105,8 @@ class Submission(models.Model):
     def long_status(self):
         return Submission.USER_DISPLAY_CODES.get(self.short_status, '')
 
-    def judge(self, rejudge, **kwargs):
-        judge_submission(self, rejudge, **kwargs)
+    def judge(self, rejudge):
+        judge_submission(self, rejudge)
 
     judge.alters_data = True
 

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -546,7 +546,7 @@ def problem_submit(request, problem=None, submission=None):
                 model = form.save()
 
             profile.update_contest()
-            model.judge()
+            model.judge(rejudge=False)
             return HttpResponseRedirect(reverse('submission_status', args=[str(model.id)]))
         else:
             form_data = form.cleaned_data

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -32,7 +32,7 @@ def rejudge_submission(request):
             not submission.problem.is_editor(request.user.profile):
         return HttpResponseForbidden()
 
-    submission.judge(rejudged=True)
+    submission.judge(rejudge=True)
 
     redirect = request.POST.get('path', None)
 

--- a/judge/views/widgets.py
+++ b/judge/views/widgets.py
@@ -32,7 +32,7 @@ def rejudge_submission(request):
             not submission.problem.is_editor(request.user.profile):
         return HttpResponseForbidden()
 
-    submission.judge(was_rejudged=True)
+    submission.judge(rejudged=True)
 
     redirect = request.POST.get('path', None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ ua-parser
 pyyaml
 jinja2
 django_jinja
+llist


### PR DESCRIPTION
Using a linked list as our submission queue. This allows submissions to be inserted into the queue, right before the priority marker for its priority. Higher number means lower priority.

Rejudges now have priority 1, compared to first submissions which have priority 0.