### PR TITLE
Don't show editorial link for private editorials

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db import connection, IntegrityError
-from django.db.models import Q, Min, Max, Count
+from django.db.models import Q, Min, Max, Count, Sum, Case, When, IntegerField
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
@@ -199,7 +199,8 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         context = super(ContestDetail, self).get_context_data(**kwargs)
         context['contest_problems'] = Problem.objects.filter(contests__contest=self.object) \
             .order_by('contests__order').defer('description') \
-            .annotate(has_editorial=Count('solution')) \
+            .annotate(has_public_editorial=Sum(Case(When(solution__is_public=True, then=1), \
+                                             default=0, output_field=IntegerField()))) \
             .add_i18n_name(self.request.LANGUAGE_CODE)
         return context
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -199,8 +199,8 @@ class ContestDetail(ContestMixin, TitleMixin, CommentedDetailView):
         context = super(ContestDetail, self).get_context_data(**kwargs)
         context['contest_problems'] = Problem.objects.filter(contests__contest=self.object) \
             .order_by('contests__order').defer('description') \
-            .annotate(has_public_editorial=Sum(Case(When(solution__is_public=True, then=1), \
-                                             default=0, output_field=IntegerField()))) \
+            .annotate(has_public_editorial=Sum(Case(When(solution__is_public=True, then=1),
+                                                    default=0, output_field=IntegerField()))) \
             .add_i18n_name(self.request.LANGUAGE_CODE)
         return context
 

--- a/templates/contest/contest.html
+++ b/templates/contest/contest.html
@@ -95,7 +95,7 @@
                         <td>{{ problem.ac_rate|floatformat(1) }}%</td>
                         <td><a href="{{ url('ranked_submissions', problem.code) }}">{{ problem.user_count }}</a></td>
                         <td>
-                            {%- if problem.has_editorial -%}
+                            {%- if problem.has_public_editorial -%}
                                 <a href="{{ url('problem_editorial', problem.code) }}">{{ _('Editorial') }}</a>
                             {%- endif -%}
                         </td>


### PR DESCRIPTION
Renamed `has_editorial` to `has_public_editorial`, which is more accurate, and implemented the functionality. @quantum5 @Xyene please check the efficiency of the queries.