### PR TITLE
Remove `math_engine` from `ProfileForm` if there is no `MATHOID_URL`.

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -27,15 +27,19 @@ class ProfileForm(ModelForm):
 
     class Meta:
         model = Profile
-        fields = ['name', 'about', 'organizations', 'timezone', 'language', 'ace_theme', 'user_script', 'math_engine']
+        fields = ['name', 'about', 'organizations', 'timezone', 'language', 'ace_theme', 'user_script']
         widgets = {
             'name': TextInput(attrs={'style': 'width:100%;box-sizing:border-box'}),
             'user_script': AceWidget(theme='github'),
             'timezone': Select2Widget(attrs={'style': 'width:200px'}),
             'language': Select2Widget(attrs={'style': 'width:200px'}),
             'ace_theme': Select2Widget(attrs={'style': 'width:200px'}),
-            'math_engine': Select2Widget(attrs={'style': 'width:200px'})
         }
+
+        has_math_config = bool(getattr(settings, 'MATHOID_URL', False))
+        if has_math_config:
+            fields.append('math_engine')
+            widgets['math_engine'] = Select2Widget(attrs={'style': 'width:200px'})
 
         if HeavyPreviewPageDownWidget is not None:
             widgets['about'] = HeavyPreviewPageDownWidget(


### PR DESCRIPTION
Addresses #642.