### PR TITLE
Only key should be included in get()

### DIFF
--- a/judge/models/runtime.py
+++ b/judge/models/runtime.py
@@ -88,7 +88,7 @@ class Language(models.Model):
     @classmethod
     def get_python2(cls):
         # We really need a default language, and this app is in Python 2
-        return Language.objects.get_or_create(key='PY2', defaults={ 'name'='Python 2' })[0]
+        return Language.objects.get_or_create(key='PY2', defaults={'name': 'Python 2'})[0]
 
     def get_absolute_url(self):
         return reverse('runtime_list') + '#' + self.key

--- a/judge/models/runtime.py
+++ b/judge/models/runtime.py
@@ -88,7 +88,7 @@ class Language(models.Model):
     @classmethod
     def get_python2(cls):
         # We really need a default language, and this app is in Python 2
-        return Language.objects.get_or_create(key='PY2', name='Python 2')[0]
+        return Language.objects.get_or_create(key='PY2', defaults={ 'name'='Python 2' })[0]
 
     def get_absolute_url(self):
         return reverse('runtime_list') + '#' + self.key


### PR DESCRIPTION
If the admin changed the long name of Python 2 (which is sometimes reasonable), the registration will fail because we can't find `key=PY2` as well as `name=Python 2` this time.
Therefore, only`name='Python 2'` should be used when searching the language object, while both are used when creating such a language object.