### PR TITLE
Update new_rating before computing new_volatility.

### DIFF
--- a/judge/ratings.py
+++ b/judge/ratings.py
@@ -70,11 +70,12 @@ def recalculate_ratings(old_rating, old_volatility, actual_rank, times_rated):
 
         Cap = 150.0 + 1500.0 / (times_rated[i] + 2)
 
+        new_rating[i] = (old_rating[i] + Weight * PerfAs) / (1.0 + Weight)
+
         if times_rated[i] == 0:
             new_volatility[i] = 385
         else:
             new_volatility[i] = math.sqrt(((new_rating[i] - old_rating[i]) ** 2) / Weight + (old_volatility[i] ** 2) / (Weight + 1))
-        new_rating[i] = (old_rating[i] + Weight * PerfAs) / (1.0 + Weight)
         if abs(old_rating[i] - new_rating[i]) > Cap:
             if old_rating[i] < new_rating[i]:
                 new_rating[i] = old_rating[i] + Cap


### PR DESCRIPTION
new_rating is initialized to always be equal to old_rating, which explains why volatility never increased for any users