### PR TITLE
Don't show language limit overrides if they're the same as default

### DIFF
--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -255,8 +255,9 @@ class Problem(models.Model):
     update_stats.alters_data = True
 
     def _get_limits(self, key):
+        global_limit = getattr(self, key)
         limits = {limit['language_id']: (limit['language__name'], limit[key])
-                  for limit in self.language_limits.values('language_id', 'language__name', key)}
+                  for limit in self.language_limits.values('language_id', 'language__name', key) if limit[key] != global_limit}
         limit_ids = set(limits.keys())
         common = []
 


### PR DESCRIPTION
This is done in the model instead of the template so that the changes are automatically reflected when #790 is implemented.