### PR TITLE
support prefix on navbar urls

### DIFF
--- a/judge/fixtures/navbar.json
+++ b/judge/fixtures/navbar.json
@@ -7,7 +7,7 @@
             "lft": 1,
             "order": 1,
             "parent": null,
-            "path": "/problems/",
+            "path": "problems/",
             "regex": "^/problem",
             "rght": 2,
             "tree_id": 1
@@ -23,7 +23,7 @@
             "lft": 1,
             "order": 2,
             "parent": null,
-            "path": "/submissions/",
+            "path": "submissions/",
             "regex": "^/submi|^/src/",
             "rght": 2,
             "tree_id": 2
@@ -39,7 +39,7 @@
             "lft": 1,
             "order": 3,
             "parent": null,
-            "path": "/users/",
+            "path": "users/",
             "regex": "^/user",
             "rght": 2,
             "tree_id": 3
@@ -55,7 +55,7 @@
             "lft": 1,
             "order": 5,
             "parent": null,
-            "path": "/contests/",
+            "path": "contests/",
             "regex": "^/contest",
             "rght": 2,
             "tree_id": 4
@@ -71,7 +71,7 @@
             "lft": 1,
             "order": 6,
             "parent": null,
-            "path": "/about/",
+            "path": "about/",
             "regex": "^/about/$",
             "rght": 4,
             "tree_id": 5
@@ -87,7 +87,7 @@
             "lft": 2,
             "order": 7,
             "parent": 6,
-            "path": "/status/",
+            "path": "status/",
             "regex": "^/status/$|^/judge/",
             "rght": 3,
             "tree_id": 5

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,7 +185,7 @@
             <li class="home-menu-item"><a href="{{ url('home') }}" class="nav-home">{{ _('Home') }}</a></li>
             {% for node in mptt_tree(nav_bar) recursive %}
                 <li>
-                    <a href="{{ node.path }}" class="nav-{{ node.key }}{% if node.key in nav_tab %} active{% endif %}">
+                    <a href="{{ url('home') }}{{ node.path }}" class="nav-{{ node.key }}{% if node.key in nav_tab %} active{% endif %}">
                         {{ user_trans(node.label) }}
                         {% if not node.is_leaf_node %}
                             <div href="javascript:void(0)" class="nav-expand">></div>


### PR DESCRIPTION
 - Give support to prefix for navbar urls on the site
 - Give opportunity to reverse proxy the whole site on a different location , example : 

Instead of running your site on https://example.com/ you can run it on https://example.com/dmoj/

using simply the "script_name" variable in uwsgi and nginx (or apache if wanted).

I will document more this part when proposing my docker-compose implementation of dmoj-site, dmoj-db and dmoj-judge.

Anyway this works as a standalone in the code but give more flexibility without making any noticeable difference when running the site on "/"