### PR TITLE
Display members' full name for super user.

### DIFF
--- a/templates/user/base-users-table.html
+++ b/templates/user/base-users-table.html
@@ -19,7 +19,11 @@
     <tr id="user-{{ user.user.username }}">
         <td>{{ rank }}</td>
         {% block after_rank scoped %}{% endblock %}
-        <td class="user-name">{{ link_user(user) }}</td>
+        {% if request.user.is_staff or request.user.is_superuser %}
+            <td class="user-name">{{ link_user(user) }} - ({{ (user.user.first_name) }} {{ (user.user.last_name) }})</td>
+        {% else %}
+            <td class="user-name">{{ link_user(user) }} </td>
+        {% endif %}
         {% block before_point scoped %}{% endblock %}
         {% block point scoped %}
             <td title="{{ user.performance_points|floatformat(2) }}" class="user-points">


### PR DESCRIPTION
As a superuser (or staff), just listing all member's username is not very informative. (My site use the student number as username).
So I show the full name next to the username in the username list.