### PR TITLE
Add "My tickets" on problem pages

### DIFF
--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -288,9 +288,11 @@ class ProblemTicketListView(TicketList):
         if 'problem' not in self.kwargs:
             raise Http404()
         problem = Problem.objects.get(code=self.kwargs['problem'])
-        if not self.request.user.is_authenticated or not problem.is_editable_by(self.request.user):
-            raise Http404()
-        return problem.tickets.all()
+        if problem.is_editable_by(self.request.user):
+            return problem.tickets.all()
+        elif problem.is_accessible_by(self.request.user):
+            return problem.tickets.filter(own_ticket_filter(self.profile.id))
+        raise Http404()
 
 
 class TicketListDataAjax(TicketMixin, SingleObjectMixin, View):

--- a/templates/problem/problem.html
+++ b/templates/problem/problem.html
@@ -139,6 +139,13 @@
         {% if not problem.is_manually_managed %}
             <div><a href="{{ url('problem_data', problem.code) }}">{{ _('Edit test data') }}</a></div>
         {% endif %}
+    {% elif request.user.is_authenticated and has_tickets %}
+        <hr>
+        <div>
+            <a href="{{ url('problem_ticket_list', problem.code) }}">{{ _('My tickets') }}
+                {% if num_open_tickets %}<span class="badge">{{ num_open_tickets }}</span>{% endif %}
+            </a>
+        </div>
     {% endif %}
 
     {% if perms.judge.clone_problem %}


### PR DESCRIPTION
Currently, the only way for normal users to view the tickets they have submitted is on https://dmoj.ca/tickets. However, many users who are just beginning do not realize that the page exists, as there is no link to it anywhere. Many users submit a ticket, and think they lose access to it, and never see the problem setter's response. 

I suggest that a "My tickets" link be added to each problem page, similar to how curators and authors can see the tickets for their problems. The "My tickets" would link to a page which shows the user the tickets they have submitted for the problem.