### PR TITLE
Cache submission statistics table for unfiltered global submissions list

### DIFF
--- a/judge/utils/problems.py
+++ b/judge/utils/problems.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from django.db.models import F, Count, Max, Q, ExpressionWrapper, Case, When
 from django.db.models.fields import FloatField
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, gettext_noop
 
 from judge.models import Submission, Problem
 
@@ -81,11 +81,13 @@ def get_result_data(*args, **kwargs):
 
     return {
         'categories': [
-            {'code': 'AC', 'name': _('Accepted'), 'count': results['AC']},
-            {'code': 'WA', 'name': _('Wrong'), 'count': results['WA']},
-            {'code': 'CE', 'name': _('Compile Error'), 'count': results['CE']},
-            {'code': 'TLE', 'name': _('Timeout'), 'count': results['TLE']},
-            {'code': 'ERR', 'name': _('Error'),
+            # Using gettext_noop here since this will be tacked into the cache, so it must be language neutral.
+            # The caller, SubmissionList.get_result_data will run ugettext on the name.
+            {'code': 'AC', 'name': gettext_noop('Accepted'), 'count': results['AC']},
+            {'code': 'WA', 'name': gettext_noop('Wrong'), 'count': results['WA']},
+            {'code': 'CE', 'name': gettext_noop('Compile Error'), 'count': results['CE']},
+            {'code': 'TLE', 'name': gettext_noop('Timeout'), 'count': results['TLE']},
+            {'code': 'ERR', 'name': gettext_noop('Error'),
              'count': results['MLE'] + results['OLE'] + results['IR'] + results['RTE'] + results['AB'] + results['IE']},
         ],
         'total': sum(results.values()),

--- a/judge/views/ranked_submission.py
+++ b/judge/views/ranked_submission.py
@@ -62,7 +62,7 @@ class RankedSubmissions(ProblemSubmissions):
         return format_html(_(u'Best solutions for <a href="{1}">{0}</a>'), self.problem_name,
                            reverse('problem_detail', args=[self.problem.code]))
 
-    def get_result_data(self):
+    def _get_result_data(self):
         return get_result_data(super(RankedSubmissions, self).get_queryset().order_by())
 
 
@@ -82,6 +82,6 @@ class ContestRankedSubmission(ForceContestMixin, RankedSubmissions):
         return format_html(_(u'Best solutions for problem {0} in <a href="{2}">{1}</a>'),
                             self.get_problem_number(self.problem), self.contest.name, reverse('contest_view', args=[self.contest.key]))
 
-    def get_result_data(self):
+    def _get_result_data(self):
         return get_result_data(Submission.objects.filter(
                 problem_id=self.problem.id, contest__participation__contest_id=self.contest.id))

--- a/templates/submission/list.html
+++ b/templates/submission/list.html
@@ -156,11 +156,16 @@
                 };
 
                 var stats_outdated = false;
+                var last_stat_update = Date.now();
+                var stats_update_interval = {{ stats_update_interval|default(0) }};
 
                 function update_stats() {
+                    if (Date.now() - last_stat_update < stats_update_interval)
+                        return;
                     $.ajax({
                         url: '?results'
                     }).done(function (data) {
+                        last_stat_update = Date.now();
                         stats_graph(data);
                     }).fail(function () {
                         console.log('Failed to update statistics table!' + id);


### PR DESCRIPTION
To do:

* [x] make `_get_result_data` not cache language/status filters
* [x] only update table via Ajax after cache clears
* [x] make cache time configurable, or at least have one place to control it (once we add ajax timeout)