### PR TITLE
Fix placing of `pretest-*` CSS classes

### DIFF
--- a/judge/contest_format/default.py
+++ b/judge/contest_format/default.py
@@ -49,7 +49,7 @@ class DefaultContestFormat(BaseContestFormat):
         if format_data:
             return format_html(
                 u'<td class="{state}"><a href="{url}">{points}<div class="solving-time">{time}</div></a></td>',
-                state=('pretest-' if contest_problem.is_pretested else '') +
+                state=('pretest-' if self.contest.run_pretests_only and contest_problem.is_pretested else '') +
                       self.best_solution_state(format_data['points'], contest_problem.points),
                 url=reverse('contest_user_submissions',
                             args=[self.contest.key, participation.user.user.username, contest_problem.problem.code]),


### PR DESCRIPTION
If a contest is not marked as `run_pretests_only`, prestests will not be run, even if `is_pretested` is true for a contest problem. However, not all contest setters diable both flags once a problem has been system tested, which gives the false impression that the problem was not system tested yet.