### PR TITLE
Prefix all constants with DMOJ_

### DIFF
--- a/dmoj/throttle_mail.py
+++ b/dmoj/throttle_mail.py
@@ -8,7 +8,7 @@ DEFAULT_THROTTLE = (10, 60)
 
 
 def new_email():
-    cache.add('error_email_throttle', 0, getattr(settings, 'EMAIL_THROTTLING', DEFAULT_THROTTLE)[1])
+    cache.add('error_email_throttle', 0, getattr(settings, 'DMOJ_EMAIL_THROTTLING', DEFAULT_THROTTLE)[1])
     return cache.incr('error_email_throttle')
 
 
@@ -16,7 +16,7 @@ class ThrottledEmailHandler(AdminEmailHandler):
     def __init__(self, *args, **kwargs):
         super(ThrottledEmailHandler, self).__init__(*args, **kwargs)
 
-        self.throttle = getattr(settings, 'EMAIL_THROTTLING', DEFAULT_THROTTLE)[0]
+        self.throttle = getattr(settings, 'DMOJ_EMAIL_THROTTLING', DEFAULT_THROTTLE)[0]
 
     def emit(self, record):
         try:

--- a/judge/admin/contest.py
+++ b/judge/admin/contest.py
@@ -171,7 +171,7 @@ class ContestAdmin(VersionAdmin):
 
         queryset = ContestSubmission.objects.filter(problem_id=problem_id).select_related('submission')
         if not request.user.has_perm('judge.rejudge_submission_lot') and \
-                len(queryset) > getattr(settings, 'REJUDGE_SUBMISSION_LIMIT', 10):
+                len(queryset) > getattr(settings, 'DMOJ_SUBMISSIONS_REJUDGE_LIMIT', 10):
             self.message_user(request, ugettext('You do not have the permission to rejudge THAT many submissions.'),
                               level=messages.ERROR)
             return

--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -135,7 +135,7 @@ class SubmissionAdmin(admin.ModelAdmin):
             return
         queryset = queryset.order_by('id')
         if not request.user.has_perm('judge.rejudge_submission_lot') and \
-                queryset.count() > getattr(settings, 'REJUDGE_SUBMISSION_LIMIT', 10):
+                queryset.count() > getattr(settings, 'DMOJ_SUBMISSIONS_REJUDGE_LIMIT', 10):
             self.message_user(request, ugettext('You do not have the permission to rejudge THAT many submissions.'),
                               level=messages.ERROR)
             return

--- a/judge/comments.py
+++ b/judge/comments.py
@@ -117,6 +117,6 @@ class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
             context['is_new_user'] = (not self.request.user.is_staff and
                                       not profile.submission_set.filter(points=F('problem__points')).exists())
         context['comment_list'] = queryset
-        context['vote_hide_threshold'] = getattr(settings, 'COMMENT_VOTE_HIDE_THRESHOLD', -5)
+        context['vote_hide_threshold'] = getattr(settings, 'DMOJ_COMMENT_VOTE_HIDE_THRESHOLD', -5)
 
         return context

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -50,7 +50,7 @@ class ProfileForm(ModelForm):
 
     def clean(self):
         organizations = self.cleaned_data.get('organizations') or []
-        max_orgs = getattr(settings, 'MAX_USER_ORGANIZATION_COUNT', 3)
+        max_orgs = getattr(settings, 'DMOJ_USER_MAX_ORGANIZATION_COUNT', 3)
 
         if sum(org.is_open for org in organizations) > max_orgs:
             raise ValidationError(_('You may not be part of more than {count} public organizations.').format(count=max_orgs))

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -120,13 +120,17 @@ class Profile(models.Model):
     def username(self):
         return self.user.username
 
-    def calculate_points(self, table=(lambda x: [pow(x, i) for i in xrange(100)])(getattr(settings, 'PP_STEP', 0.95))):
+    _pp_step = getattr(settings, 'DMOJ_PP_STEP', 0.95)
+    _pp_table = [pow(_pp_step, i) for i in xrange(getattr(settings, 'DMOJ_PP_ENTRIES', 100))]
+    def calculate_points(self, table=_pp_table):
         from judge.models import Problem
-        data = (Problem.objects.filter(submission__user=self, submission__points__isnull=False, is_public=True, is_organization_private=False)
-                .annotate(max_points=Max('submission__points')).order_by('-max_points')
-                .values_list('max_points', flat=True).filter(max_points__gt=0))
-        extradata = Problem.objects.filter(submission__user=self, submission__result='AC', is_public=True).values('id').distinct().count()
-        bonus_function = getattr(settings, 'PP_BONUS_FUNCTION', lambda n: 300 * (1 - 0.997 ** n))
+        data = (Problem.objects.filter(submission__user=self, submission__points__isnull=False, is_public=True,
+                                       is_organization_private=False)
+                    .annotate(max_points=Max('submission__points')).order_by('-max_points')
+                    .values_list('max_points', flat=True).filter(max_points__gt=0))
+        extradata = Problem.objects.filter(submission__user=self, submission__result='AC', is_public=True) \
+                        .values('id').distinct().count()
+        bonus_function = getattr(settings, 'DMOJ_PP_BONUS_FUNCTION', lambda n: 300 * (1 - 0.997 ** n))
         points = sum(data)
         problems = len(data)
         entries = min(len(data), len(table))

--- a/judge/pdf_problems.py
+++ b/judge/pdf_problems.py
@@ -19,7 +19,7 @@ NODE_PATH = getattr(settings, 'NODEJS', '/usr/bin/node')
 PUPPETEER_MODULE = getattr(settings, 'PUPPETEER_MODULE', '/usr/lib/node_modules/puppeteer')
 HAS_PUPPETEER = os.access(NODE_PATH, os.X_OK) and os.path.isdir(PUPPETEER_MODULE)
 
-HAS_PDF = (os.path.isdir(getattr(settings, 'PROBLEM_PDF_CACHE', '')) and
+HAS_PDF = (os.path.isdir(getattr(settings, 'DMOJ_PDF_PROBLEM_CACHE', '')) and
            (HAS_PHANTOMJS or HAS_SLIMERJS or HAS_PUPPETEER))
 
 EXIFTOOL = getattr(settings, 'EXIFTOOL', '/usr/bin/exiftool')
@@ -33,7 +33,7 @@ class BasePdfMaker(object):
     title = None
 
     def __init__(self, dir=None, clean_up=True):
-        self.dir = dir or os.path.join(getattr(settings, 'PROBLEM_PDF_TEMP_DIR', tempfile.gettempdir()),
+        self.dir = dir or os.path.join(getattr(settings, 'DMOJ_PDF_PROBLEM_TEMP_DIR', tempfile.gettempdir()),
                                        str(uuid.uuid1()))
         self.proc = None
         self.log = None

--- a/judge/performance_points.py
+++ b/judge/performance_points.py
@@ -6,8 +6,8 @@ from django.db import connection
 from judge.models import Submission
 from judge.timezone import from_database_time
 
-PP_STEP = getattr(settings, 'PP_STEP', 0.95)
-PP_ENTRIES = getattr(settings, 'PP_ENTRIES', 100)
+PP_STEP = getattr(settings, 'DMOJ_PP_STEP', 0.95)
+PP_ENTRIES = getattr(settings, 'DMOJ_PP_ENTRIES', 100)
 PP_WEIGHT_TABLE = [pow(PP_STEP, i) for i in xrange(PP_ENTRIES)]
 
 PPBreakdown = namedtuple('PPBreakdown', 'points weight scaled_points problem_name problem_code '
@@ -15,7 +15,7 @@ PPBreakdown = namedtuple('PPBreakdown', 'points weight scaled_points problem_nam
                                         'sub_short_status sub_long_status sub_lang')
 
 
-def get_pp_breakdown(user, start=0, end=100):
+def get_pp_breakdown(user, start=0, end=PP_ENTRIES):
     with connection.cursor() as cursor:
         cursor.execute('''
             SELECT max_points_table.problem_code,

--- a/judge/utils/camo.py
+++ b/judge/utils/camo.py
@@ -36,9 +36,9 @@ class CamoClient(object):
                 obj.set('data', self.rewrite_url(obj.get('data')))
 
 
-if getattr(settings, 'CAMO_URL', None) and getattr(settings, 'CAMO_KEY', None):
-    client = CamoClient(settings.CAMO_URL, key=settings.CAMO_KEY,
-                        excluded=getattr(settings, 'CAMO_EXCLUDE', ()),
-                        https=getattr(settings, 'CAMO_HTTPS', False))
+if getattr(settings, 'DMOJ_CAMO_URL', None) and getattr(settings, 'DMOJ_CAMO_KEY', None):
+    client = CamoClient(settings.DMOJ_CAMO_URL, key=settings.DMOJ_CAMO_KEY,
+                        excluded=getattr(settings, 'DMOJ_CAMO_EXCLUDE', ()),
+                        https=getattr(settings, 'DMOJ_CAMO_HTTPS', False))
 else:
     client = None

--- a/judge/utils/problem_data.py
+++ b/judge/utils/problem_data.py
@@ -19,7 +19,7 @@ else:
 
 class ProblemDataStorage(FileSystemStorage):
     def __init__(self):
-        super(ProblemDataStorage, self).__init__(getattr(settings, 'PROBLEM_DATA_ROOT', None))
+        super(ProblemDataStorage, self).__init__(getattr(settings, 'DMOJ_PROBLEM_DATA_ROOT', None))
 
     def url(self, name):
         path = split_path_first(name)

--- a/judge/views/organization.py
+++ b/judge/views/organization.py
@@ -126,7 +126,7 @@ class JoinOrganization(OrganizationMembershipChange):
         if not org.is_open:
             return generic_message(request, _('Joining organization'), _('This organization is not open.'))
 
-        max_orgs = getattr(settings, 'MAX_USER_ORGANIZATION_COUNT', 3)
+        max_orgs = getattr(settings, 'DMOJ_USER_MAX_ORGANIZATION_COUNT', 3)
         if profile.organizations.filter(is_open=True).count() >= max_orgs:
             return generic_message(request, _('Joining organization'), _('You may not be part of more than {count} public organizations.').format(count=max_orgs))
 


### PR DESCRIPTION
New naming convention for constants is `DMOJ_MODULE_<NAME>`, as decided in Slack.