### PR TITLE
Fix version matrix judge name parsing.

### DIFF
--- a/judge/views/status.py
+++ b/judge/views/status.py
@@ -40,10 +40,9 @@ class LatestList(list):
 
 
 def compare_version_list(x, y):
-    keys = list(x.keys())
-    if keys != list(y.keys()):
+    if sorted(x.keys()) != sorted(y.keys()):
         return False
-    for k in keys:
+    for k in x.keys():
         if len(x[k]) != len(y[k]):
             return False
         for a, b in zip(x[k], y[k]):


### PR DESCRIPTION
In Python 3, dictionary keys are not sorted, which means that parsing judge names (such as `a.1` and `a.2`) does not work as `compare_version_list` will return `False`.