### PR TITLE
Remove version requirements on django-registration-redux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.11,<2
 django_compressor
 django-mptt>=0.8.4,<0.9
 -e git://github.com/DMOJ/django-pagedown.git#egg=django-pagedown
-django-registration-redux>=1.11,<2
+django-registration-redux
 django-reversion
 django-social-share
 django-sortedm2m


### PR DESCRIPTION
There seem to be no reason why we are using the 1.x branch. It seems to be designed for pre-Django 1.11 sites.

Also, we are already running latest `django-registration-redux` in production.