### PR TITLE
Use latest version of django-mptt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.11,<2
 django_compressor
-django-mptt>=0.8.4,<0.9
+django-mptt
 -e git://github.com/DMOJ/django-pagedown.git#egg=django-pagedown
 django-registration-redux>=1.11,<2
 django-reversion


### PR DESCRIPTION
This will allow django-mptt to work on Django 2.0.