### PR TITLE
Use the latest version of django-pagedown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.11,<2
 django_compressor
 django-mptt>=0.8.4,<0.9
--e git://github.com/DMOJ/django-pagedown.git#egg=django-pagedown
+django-pagedown
 django-registration-redux>=1.11,<2
 django-reversion
 django-social-share


### PR DESCRIPTION
Originally, we forked it because there was a bug that wasn't fixed.

Now, that bug has long since been fixed in the official django-pagedown, as well as a lot more changes. It is time to abandon the temporary fork.