### PR TITLE
Remove __id__in anti-pattern

### DIFF
--- a/judge/views/blog.py
+++ b/judge/views/blog.py
@@ -68,7 +68,7 @@ class PostList(ListView):
         if self.request.user.is_authenticated:
             user = self.request.user.profile
             context['recently_attempted_problems'] = (Submission.objects.filter(user=user)
-                                                      .exclude(problem__id__in=user_completed_ids(user))
+                                                      .exclude(problem__in=user_completed_ids(user))
                                                       .values_list('problem__code', 'problem__name', 'problem__points')
                                                       .annotate(points=Max('points'), latest=Max('date'))
                                                       .order_by('-latest'))[:7]

--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -369,7 +369,7 @@ class ProblemList(QueryStringSortMixin, TitleMixin, SolvedProblemMixin, ListView
         if not self.request.user.has_perm('see_organization_problem'):
             filter = Q(is_organization_private=False)
             if self.profile is not None:
-                filter |= Q(organizations__id__in=self.profile.organizations.all())
+                filter |= Q(organizations__in=self.profile.organizations.all())
             queryset = queryset.filter(filter)
         if self.profile is not None and self.hide_solved:
             queryset = queryset.exclude(id__in=Submission.objects.filter(user=self.profile, points=F('problem__points'))

--- a/judge/views/user.py
+++ b/judge/views/user.py
@@ -153,7 +153,7 @@ class UserProblemsPage(UserPage):
 
         result = Submission.objects.filter(user=self.object, points__gt=0, problem__is_public=True,
                                            problem__is_organization_private=False) \
-            .exclude(problem__id__in=self.get_completed_problems() if self.hide_solved else []) \
+            .exclude(problem__in=self.get_completed_problems() if self.hide_solved else []) \
             .values('problem__id', 'problem__code', 'problem__name', 'problem__points', 'problem__group__full_name') \
             .distinct().annotate(points=Max('points')).order_by('problem__group__full_name', 'problem__code')
 


### PR DESCRIPTION
Basically, doing `__in` works for a foreign key, and there absolutely no reason to join in the target table just to filter the primary key.