### PR TITLE
Fix ticket messages not showing up

### DIFF
--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -152,7 +152,7 @@ class TicketView(TitleMixin, LoginRequiredMixin, TicketMixin, SingleObjectFormVi
 
     def get_context_data(self, **kwargs):
         context = super(TicketView, self).get_context_data(**kwargs)
-        context['messages'] = self.object.messages.select_related('user__user')
+        context['ticket_messages'] = self.object.messages.select_related('user__user')
         context['assignees'] = self.object.assignees.select_related('user')
         context['last_msg'] = event.last()
         return context

--- a/templates/ticket/ticket.html
+++ b/templates/ticket/ticket.html
@@ -336,7 +336,7 @@
 
         <div class="ticket-messages">
             <main class="messages">
-                {% for message in messages %}
+                {% for message in ticket_messages %}
                     <section id="message-{{ message.id }}" class="message">
                         <div class="info">
                             <a href="{{ url('user_page', message.user.user.username) }}" class="user">


### PR DESCRIPTION
Ticket messages are broken after #996. The line in question is [here](https://github.com/DMOJ/site/commit/9ba710b55c33919fcb2e47dc1415773204184e19#diff-d783d3ab1245639572a26f354d7a3b25R206), which overwrites `messages`. The proposed solution is to simply rename `messages` to `ticket_messages`.