### PR TITLE
Fix ticket notes not working

### DIFF
--- a/judge/views/ticket.py
+++ b/judge/views/ticket.py
@@ -185,10 +185,10 @@ class TicketNotesForm(forms.Form):
     notes = forms.CharField(widget=forms.Textarea(), required=False)
 
 
-class TicketNotesEditView(LoginRequiredMixin, TicketMixin, SingleObjectMixin, FormView):
+class TicketNotesEditView(LoginRequiredMixin, TicketMixin, SingleObjectFormView):
     template_name = 'ticket/edit-notes.html'
     form_class = TicketNotesForm
-    object = None
+    context_object_name = 'ticket'
 
     def get_initial(self):
         return {'notes': self.get_object().notes}


### PR DESCRIPTION
Fixes:
```Traceback (most recent call last):
  File "/code/site/siteenv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/code/site/siteenv/lib/python3.6/site-packages/django/core/handlers/base.py", line 217, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/code/site/siteenv/lib/python3.6/site-packages/django/core/handlers/base.py", line 215, in _get_response
    response = response.render()
  File "/code/site/siteenv/lib/python3.6/site-packages/django/template/response.py", line 107, in render
    self.content = self.rendered_content
  File "/code/site/siteenv/lib/python3.6/site-packages/django/template/response.py", line 84, in rendered_content
    content = template.render(context, self._request)
  File "/code/site/siteenv/lib/python3.6/site-packages/django_jinja/backend.py", line 106, in render
    return mark_safe(self.template.render(context))
  File "/code/site/siteenv/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/code/site/siteenv/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/code/site/siteenv/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/code/site/siteenv/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "./templates/ticket/edit-notes.html", line 1, in top-level template code
    <form id="edit-notes" action="{{ url('ticket_notes', ticket.id) }}" method="post">
  File "/code/site/siteenv/lib/python3.6/site-packages/jinja2/environment.py", line 430, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'ticket' is undefined
```

In particular:
1. `ticket` was never set in the context.
2. `self.object` was always `None` as it was never set.