### PR TITLE
Raise 429 when rate limiting submissions

### DIFF
--- a/judge/views/problem.py
+++ b/judge/views/problem.py
@@ -537,7 +537,7 @@ def problem_submit(request, problem=None, submission=None):
             if (not request.user.has_perm('judge.spam_submission') and
                         Submission.objects.filter(user=profile, was_rejudged=False).exclude(
                             status__in=['D', 'IE', 'CE', 'AB']).count() > 2):
-                return HttpResponse('<h1>You submitted too many submissions.</h1>', status=503)
+                return HttpResponse('<h1>You submitted too many submissions.</h1>', status=429)
             if not form.cleaned_data['problem'].allowed_languages.filter(
                     id=form.cleaned_data['language'].id).exists():
                 raise PermissionDenied()


### PR DESCRIPTION
A 429 error corresponds to `Too Many Requests`, which is more fitting than `503 Service Unavailable`. Additionally, 5XXs are logged as `ERROR` by `django.request`, whereas 4XXs are only `WARNING`.