### PR TITLE
Give batch rejudges lower priority

### DIFF
--- a/judge/admin/submission.py
+++ b/judge/admin/submission.py
@@ -158,7 +158,7 @@ class SubmissionAdmin(admin.ModelAdmin):
             queryset = queryset.filter(Q(problem__authors__id=id) | Q(problem__curators__id=id))
         judged = len(queryset)
         for model in queryset:
-            model.judge(rejudge=True)
+            model.judge(rejudge=True, batch_rejudge=True)
         self.message_user(request, ungettext('%d submission was successfully scheduled for rejudging.',
                                              '%d submissions were successfully scheduled for rejudging.',
                                              judged) % judged)

--- a/judge/bridge/judgelist.py
+++ b/judge/bridge/judgelist.py
@@ -14,7 +14,7 @@ PriorityMarker = namedtuple('PriorityMarker', 'priority')
 
 
 class JudgeList(object):
-    priorities = 3
+    priorities = 4
 
     def __init__(self):
         self.queue = dllist()

--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -110,8 +110,8 @@ class Submission(models.Model):
     def long_status(self):
         return Submission.USER_DISPLAY_CODES.get(self.short_status, '')
 
-    def judge(self, rejudge):
-        judge_submission(self, rejudge)
+    def judge(self, rejudge=False, batch_rejudge=False):
+        judge_submission(self, rejudge, batch_rejudge)
 
     judge.alters_data = True
 

--- a/judge/tasks/submission.py
+++ b/judge/tasks/submission.py
@@ -27,7 +27,7 @@ def rejudge_problem_filter(self, problem_id, id_range=None, languages=None, resu
     rejudged = 0
     with Progress(self, queryset.count()) as p:
         for submission in queryset.iterator():
-            submission.judge(rejudge=True)
+            submission.judge(rejudge=True, batch_rejudge=True)
             rejudged += 1
             if rejudged % 10 == 0:
                 p.done = rejudged


### PR DESCRIPTION
When rejudging more than one submission at a time, enqueue them to be lower priority than singular rejudges.