### PR TITLE
Filter hidden comments in view

### DIFF
--- a/judge/comments.py
+++ b/judge/comments.py
@@ -105,7 +105,7 @@ class CommentedDetailView(TemplateResponseMixin, SingleObjectMixin, View):
 
     def get_context_data(self, **kwargs):
         context = super(CommentedDetailView, self).get_context_data(**kwargs)
-        queryset = Comment.objects.filter(page=self.get_comment_page())
+        queryset = Comment.objects.filter(hidden=False, page=self.get_comment_page())
         context['has_comments'] = queryset.exists()
         context['comment_lock'] = self.is_comment_locked()
         queryset = queryset.select_related('author__user').defer('author__about').annotate(revisions=Count('versions'))

--- a/templates/comments/list.html
+++ b/templates/comments/list.html
@@ -4,7 +4,7 @@
         <ul class="comments top-level-comments new-comments">
             {% set logged_in = request.user.is_authenticated %}
             {% set profile = request.user.profile if logged_in else None %}
-            {% for node in mptt_tree(comment_list) recursive %}{% if not node.hidden %}
+            {% for node in mptt_tree(comment_list) recursive %}
                 <li id="comment-{{ node.id }}" data-revision="{{ node.revisions - 1 }}"
                     data-max-revision="{{ node.revisions - 1 }}"
                     data-revision-ajax="{{ url('comment_revision_ajax', node.id) }}" class="comment">
@@ -113,7 +113,7 @@
                     {% if children %}
                         <ul class="comments">{{ loop(children) }}</ul>{% endif %}
                 {% endwith %}
-            {% endif %}{% endfor %}
+            {% endfor %}
         </ul>
     {% elif not comment_lock %}
         <p class="no-comments-message">{{ _('There are no comments at the moment.') }}</p>


### PR DESCRIPTION
Fixes the bug where a page with hidden comments and no visible comments will fail to display `There are no comments at the moment.`