### PR TITLE
Added problem admin help text; #582

### DIFF
--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -106,18 +106,16 @@ class Problem(models.Model):
                                                   'and be listed as authors.'))
     curators = models.ManyToManyField(Profile, verbose_name=_('curators'), blank=True, related_name='curated_problems',
                                       help_text=_('These users will be able to edit the problem, '
-                                                  'but not be publicly shown as an author.'))
+                                                  'but not be listed as authors.'))
     testers = models.ManyToManyField(Profile, verbose_name=_('testers'), blank=True, related_name='tested_problems',
                                      help_text=_(
                                          'These users will be able to view the private problem, but not edit it.'))
     types = models.ManyToManyField(ProblemType, verbose_name=_('problem types'),
-                                    help_text=_('The type of problem '
-                                                '(e.g. Data Structures, Simple Math, etc.).'))
+                                    help_text=_('The type of problem, '
+                                                "as shown on the Problem's page."))
     group = models.ForeignKey(ProblemGroup, verbose_name=_('problem group'), on_delete=CASCADE,
-                                help_text=_('The group of your problem, '
-                                            'shown as Category in the problem list '
-                                            '(e.g. Fun Math, Seasonal, etc.). '
-                                            'Often used if your problem is from a contest.'))
+                                help_text=_('The group of problem, '
+                                            'shown under Category in the problem list.'))
     time_limit = models.FloatField(verbose_name=_('time limit'),
                                    help_text=_('The time limit for this problem, in seconds. '
                                                'Fractional seconds (e.g. 1.5) are supported.'))
@@ -126,8 +124,8 @@ class Problem(models.Model):
                                                    '(e.g. 64mb = 65536 kilobytes).'))
     short_circuit = models.BooleanField(default=False)
     points = models.FloatField(verbose_name=_('points'),
-                                help_text=_('Points given for problem completion. '
-                                            'Displayed with a \'p\' suffix if partial.'))
+                                help_text=_('Points awarded for problem completion. '
+                                            "Points are displayed with a 'p' suffix if partial."))
     partial = models.BooleanField(verbose_name=_('allows partial points'), default=False)
     allowed_languages = models.ManyToManyField(Language, verbose_name=_('allowed languages'),
                                             help_text=_('List of allowed submission languages.'))
@@ -135,7 +133,7 @@ class Problem(models.Model):
     is_manually_managed = models.BooleanField(verbose_name=_('manually managed'), db_index=True, default=False,
                                               help_text=_('Whether judges should be allowed to manage data or not.'))
     date = models.DateTimeField(verbose_name=_('date of publishing'), null=True, blank=True, db_index=True,
-                                help_text=_('Doesn\'t have magic ability to auto-publish due to backward compatibility'))
+                                help_text=_("Doesn't have magic ability to auto-publish due to backward compatibility"))
     banned_users = models.ManyToManyField(Profile, verbose_name=_('personae non gratae'), blank=True,
                                           help_text=_('Bans the selected users from submitting to this problem.'))
     license = models.ForeignKey(License, null=True, blank=True, on_delete=SET_NULL,

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -109,7 +109,7 @@ class Problem(models.Model):
                                                   'but not be publicly shown as an author.'))
     testers = models.ManyToManyField(Profile, verbose_name=_('testers'), blank=True, related_name='tested_problems',
                                      help_text=_(
-                                         'These users will be able to view a private problem, but not edit it.'))
+                                         'These users will be able to view the private problem, but not edit it.'))
     types = models.ManyToManyField(ProblemType, verbose_name=_('problem types'),
                                     help_text=_('The type of problem '
                                                 '(e.g. Data Structures, Simple Math, etc.).'))

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -112,7 +112,7 @@ class Problem(models.Model):
                                          'These users will be able to view the private problem, but not edit it.'))
     types = models.ManyToManyField(ProblemType, verbose_name=_('problem types'),
                                     help_text=_('The type of problem, '
-                                                "as shown on the Problem's page."))
+                                                "as shown on the problem's page."))
     group = models.ForeignKey(ProblemGroup, verbose_name=_('problem group'), on_delete=CASCADE,
                                 help_text=_('The group of problem, '
                                             'shown under Category in the problem list.'))

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -94,18 +94,30 @@ class TranslatedProblemForeignKeyQuerySet(QuerySet):
 
 class Problem(models.Model):
     code = models.CharField(max_length=20, verbose_name=_('problem code'), unique=True,
-                            validators=[RegexValidator('^[a-z0-9]+$', _('Problem code must be ^[a-z0-9]+$'))])
-    name = models.CharField(max_length=100, verbose_name=_('problem name'), db_index=True)
+                            validators=[RegexValidator('^[a-z0-9]+$', _('Problem code must be ^[a-z0-9]+$'))],
+                            help_text=_('A short, unique code for the problem, '
+                                        'used in the url after /problem/'))
+    name = models.CharField(max_length=100, verbose_name=_('problem name'), db_index=True,
+                            help_text=_('The full name of the problem, '
+                                        'as shown in the problem list and title.'))
     description = models.TextField(verbose_name=_('problem body'))
-    authors = models.ManyToManyField(Profile, verbose_name=_('creators'), blank=True, related_name='authored_problems')
+    authors = models.ManyToManyField(Profile, verbose_name=_('creators'), blank=True, related_name='authored_problems',
+                                      help_text=_('These users will be able to edit a problem, '
+                                                  'and be listed as authors.'))
     curators = models.ManyToManyField(Profile, verbose_name=_('curators'), blank=True, related_name='curated_problems',
                                       help_text=_('These users will be able to edit a problem, '
                                                   'but not be publicly shown as an author.'))
     testers = models.ManyToManyField(Profile, verbose_name=_('testers'), blank=True, related_name='tested_problems',
                                      help_text=_(
                                          'These users will be able to view a private problem, but not edit it.'))
-    types = models.ManyToManyField(ProblemType, verbose_name=_('problem types'))
-    group = models.ForeignKey(ProblemGroup, verbose_name=_('problem group'), on_delete=CASCADE)
+    types = models.ManyToManyField(ProblemType, verbose_name=_('problem types'),
+                                    help_text=_('The type of problem '
+                                                '(e.g. Data Structures, Simple Math, etc.).'))
+    group = models.ForeignKey(ProblemGroup, verbose_name=_('problem group'), on_delete=CASCADE,
+                                help_text=_('The group of your problem, '
+                                            'shown as Category in the problem list '
+                                            '(e.g. Fun Math, Seasonal, etc.). '
+                                            'Often used if your problem is from a contest.'))
     time_limit = models.FloatField(verbose_name=_('time limit'),
                                    help_text=_('The time limit for this problem, in seconds. '
                                                'Fractional seconds (e.g. 1.5) are supported.'))
@@ -113,17 +125,21 @@ class Problem(models.Model):
                                        help_text=_('The memory limit for this problem, in kilobytes '
                                                    '(e.g. 64mb = 65536 kilobytes).'))
     short_circuit = models.BooleanField(default=False)
-    points = models.FloatField(verbose_name=_('points'))
+    points = models.FloatField(verbose_name=_('points'),
+                                help_text=_('Points given for problem completion. '
+                                            'Displayed with a \'p\' suffix if partial.'))
     partial = models.BooleanField(verbose_name=_('allows partial points'), default=False)
-    allowed_languages = models.ManyToManyField(Language, verbose_name=_('allowed languages'))
+    allowed_languages = models.ManyToManyField(Language, verbose_name=_('allowed languages'),
+                                            help_text=_('List of allowed submission languages.'))
     is_public = models.BooleanField(verbose_name=_('publicly visible'), db_index=True, default=False)
     is_manually_managed = models.BooleanField(verbose_name=_('manually managed'), db_index=True, default=False,
-                                              help_text=_('Whether judges should be allowed to manage data or not'))
+                                              help_text=_('Whether judges should be allowed to manage data or not.'))
     date = models.DateTimeField(verbose_name=_('date of publishing'), null=True, blank=True, db_index=True,
-                                help_text=_("Doesn't have magic ability to auto-publish due to backward compatibility"))
+                                help_text=_('Doesn\'t have magic ability to auto-publish due to backward compatibility'))
     banned_users = models.ManyToManyField(Profile, verbose_name=_('personae non gratae'), blank=True,
                                           help_text=_('Bans the selected users from submitting to this problem.'))
-    license = models.ForeignKey(License, null=True, blank=True, on_delete=SET_NULL)
+    license = models.ForeignKey(License, null=True, blank=True, on_delete=SET_NULL,
+                                help_text=_('The license under which this problem is published.'))
     og_image = models.CharField(verbose_name=_('OpenGraph image'), max_length=150, blank=True)
     summary = models.TextField(blank=True, verbose_name=_('problem summary'),
                                help_text=_('Plain-text, shown in meta description tag, e.g. for social media.'))

--- a/judge/models/problem.py
+++ b/judge/models/problem.py
@@ -99,13 +99,13 @@ class Problem(models.Model):
                                         'used in the url after /problem/'))
     name = models.CharField(max_length=100, verbose_name=_('problem name'), db_index=True,
                             help_text=_('The full name of the problem, '
-                                        'as shown in the problem list and title.'))
+                                        'as shown in the problem list.'))
     description = models.TextField(verbose_name=_('problem body'))
     authors = models.ManyToManyField(Profile, verbose_name=_('creators'), blank=True, related_name='authored_problems',
-                                      help_text=_('These users will be able to edit a problem, '
+                                      help_text=_('These users will be able to edit the problem, '
                                                   'and be listed as authors.'))
     curators = models.ManyToManyField(Profile, verbose_name=_('curators'), blank=True, related_name='curated_problems',
-                                      help_text=_('These users will be able to edit a problem, '
+                                      help_text=_('These users will be able to edit the problem, '
                                                   'but not be publicly shown as an author.'))
     testers = models.ManyToManyField(Profile, verbose_name=_('testers'), blank=True, related_name='tested_problems',
                                      help_text=_(


### PR DESCRIPTION
Added help text for the problem admin page. The `code`, `name`, `authors`, `types`, `groups`, `points`, `allowed_languages`, `is_manually_managed`, `date`, and `license` help texts have been added or modified.

Remaining ones are `description`, `is_public`, and `og_image`, of which the first two are explanatory, and the last one is both optional and hidden under the Social Media tab. However, if somebody has a good description for `og_image` I would gladly add it.

Fixes #582