### PR TITLE
Pass user instead of request to Contest methods

### DIFF
--- a/judge/models/contest.py
+++ b/judge/models/contest.py
@@ -120,22 +120,22 @@ class Contest(models.Model):
             raise ValidationError('What is this? A contest that ended before it starts?')
         self.format_class.validate(self.format_config)
 
-    def is_in_contest(self, request):
-        if request.user.is_authenticated:
-            profile = request.user.profile
+    def is_in_contest(self, user):
+        if user.is_authenticated:
+            profile = user.profile
             return profile and profile.current_contest is not None and profile.current_contest.contest == self
         return False
 
-    def can_see_scoreboard(self, request):
-        if request.user.has_perm('judge.see_private_contest'):
+    def can_see_scoreboard(self, user):
+        if user.has_perm('judge.see_private_contest'):
             return True
-        if request.user.is_authenticated and self.organizers.filter(id=request.user.profile.id).exists():
+        if user.is_authenticated and self.organizers.filter(id=user.profile.id).exists():
             return True
         if not self.is_public:
             return False
         if self.start_time is not None and self.start_time > timezone.now():
             return False
-        if self.hide_scoreboard and not self.is_in_contest(request) and self.end_time > timezone.now():
+        if self.hide_scoreboard and not self.is_in_contest(user) and self.end_time > timezone.now():
             return False
         return True
 

--- a/judge/views/api/api_v1.py
+++ b/judge/views/api/api_v1.py
@@ -31,8 +31,8 @@ def api_v1_contest_list(request):
 def api_v1_contest_detail(request, contest):
     contest = get_object_or_404(Contest, key=contest)
 
-    in_contest = contest.is_in_contest(request)
-    can_see_rankings = contest.can_see_scoreboard(request)
+    in_contest = contest.is_in_contest(request.user)
+    can_see_rankings = contest.can_see_scoreboard(request.user)
     if contest.hide_scoreboard and in_contest:
         can_see_rankings = False
 

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -477,7 +477,7 @@ def get_contest_ranking_list(request, contest, participation=None, ranking_list=
                              show_current_virtual=True, ranker=ranker):
     problems = list(contest.contest_problems.select_related('problem').defer('problem__description').order_by('order'))
 
-    if contest.hide_scoreboard and contest.is_in_contest(request):
+    if contest.hide_scoreboard and contest.is_in_contest(request.user):
         return ([(_('???'), make_contest_ranking_profile(contest, request.user.profile.current_contest, problems))],
                 problems)
 
@@ -498,7 +498,7 @@ def contest_ranking_ajax(request, contest, participation=None):
     if not exists:
         return HttpResponseBadRequest('Invalid contest', content_type='text/plain')
 
-    if not contest.can_see_scoreboard(request):
+    if not contest.can_see_scoreboard(request.user):
         raise Http404()
 
     users, problems = get_contest_ranking_list(request, contest, participation)

--- a/judge/views/select2.py
+++ b/judge/views/select2.py
@@ -116,7 +116,7 @@ class UserSearchSelect2View(BaseListView):
 class ContestUserSearchSelect2View(UserSearchSelect2View):
     def get_queryset(self):
         contest = get_object_or_404(Contest, key=self.kwargs['contest'])
-        if not contest.can_see_scoreboard(self.request) or contest.hide_scoreboard and contest.is_in_contest(self.request):
+        if not contest.can_see_scoreboard(self.request.user) or contest.hide_scoreboard and contest.is_in_contest(self.request.user):
             raise Http404()
 
         return Profile.objects.filter(contest_history__contest=contest,

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -195,8 +195,8 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
                                                               language=self.request.LANGUAGE_CODE), to_attr='_trans'))
         if self.in_contest:
             queryset = queryset.filter(contest__participation__contest_id=self.contest.id)
-            if self.contest.hide_scoreboard and self.contest.is_in_contest(self.request):
-                queryset = queryset.filter(contest__participation__user=self.request.user.profile)
+            if self.contest.hide_scoreboard and self.contest.is_in_contest(self.request.user):
+                queryset = queryset.filter(contest__participation__user=self.request.profile)
         else:
             queryset = queryset.select_related('contest__participation__contest') \
                 .defer('contest__participation__contest__description')
@@ -340,7 +340,7 @@ class ProblemSubmissionsBase(SubmissionsListBase):
                            reverse('problem_detail', args=[self.problem.code]))
 
     def access_check_contest(self, request):
-        if self.in_contest and not self.contest.can_see_scoreboard(request):
+        if self.in_contest and not self.contest.can_see_scoreboard(request.user):
             raise Http404()
 
     def access_check(self, request):

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -4,7 +4,7 @@
     {{ make_tab('detail', 'fa-info-circle', url('contest_view', contest.key), _('Info')) }}
 
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
-        {% if contest.show_scoreboard or contest.can_see_scoreboard(request) %}
+        {% if contest.show_scoreboard or contest.can_see_scoreboard(request.user) %}
             {{ make_tab('ranking', 'fa-bar-chart', url('contest_ranking', contest.key), _('Rankings')) }}
         {% else %}
             {{ make_tab('ranking', 'fa-bar-chart', None, _('Hidden Rankings')) }}

--- a/templates/contest/list.html
+++ b/templates/contest/list.html
@@ -110,7 +110,7 @@
 {% endmacro %}
 
 {% macro user_count(contest, user) %}
-    {% if contest.show_scoreboard or contest.can_see_scoreboard(request) %}
+    {% if contest.show_scoreboard or contest.can_see_scoreboard(user) %}
         <a href="{{ url('contest_ranking', contest.key) }}">{{ contest.user_count }}</a>
     {% else %}
         {{ contest.user_count }}


### PR DESCRIPTION
All other helper methods have a `user` parameter instead of a `request` parameter (`Problem.is_accessible_by`, `Problem.is_editable_by`, `Contest.is_accessible_by`, etc.) Only `Contest.is_in_contest` and `Contest.can_see_scoreboard` are passed as `request`.

This pull request changes `is_in_contest` and `can_see_scoreboard` to receive a `user` instead.