### PR TITLE
Remove joins when querying submission list pages

### DIFF
--- a/judge/models/submission.py
+++ b/judge/models/submission.py
@@ -142,10 +142,10 @@ class Submission(models.Model):
     def is_graded(self):
         return self.status not in ('QU', 'P', 'G')
 
-    @property
+    @cached_property
     def contest_key(self):
         if hasattr(self, 'contest'):
-            return self.contest.participation.contest.key
+            return self.contest_object.key
 
     def __str__(self):
         return 'Submission %d of %s by %s' % (self.id, self.problem, self.user.user.username)

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ImproperlyConfigured
-from django.db.models import Prefetch, Q, F
+from django.db.models import Prefetch, Q
 from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
@@ -28,7 +28,7 @@ def submission_related(queryset):
     return queryset.select_related('user__user', 'problem', 'language') \
         .only('id', 'user__user__username', 'user__display_rank', 'user__rating', 'problem__name',
               'problem__code', 'problem__is_public', 'language__short_name', 'language__key', 'date', 'time', 'memory',
-              'points', 'result', 'status', 'case_points', 'case_total', 'current_testcase')
+              'points', 'result', 'status', 'case_points', 'case_total', 'current_testcase', 'contest_object')
 
 
 class SubmissionMixin(object):
@@ -198,7 +198,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
             if self.contest.hide_scoreboard and self.contest.is_in_contest(self.request.user):
                 queryset = queryset.filter(contest__participation__user=self.request.profile)
         else:
-            queryset = queryset.annotate(contest_key=F('contest_object__key'), contest_name=F('contest_object__name'))
+            queryset = queryset.select_related('contest_object').defer('contest_object__description')
 
             # This is not technically correct since contest organizers *should* see these, but
             # the join would be far too messy
@@ -416,10 +416,6 @@ def single_submission(request, submission_id, show_problem=True):
     request.no_profile_update = True
     authenticated = request.user.is_authenticated
     submission = get_object_or_404(submission_related(Submission.objects.all()), id=int(submission_id))
-
-    if submission.contest_object:
-        submission.contest_key = submission.contest_object.key
-        submission.contest_name = submission.contest_object.name
 
     if not submission.problem.is_accessible_by(request.user):
         raise Http404()

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -198,8 +198,7 @@ class SubmissionsListBase(DiggPaginatorMixin, TitleMixin, ListView):
             if self.contest.hide_scoreboard and self.contest.is_in_contest(self.request.user):
                 queryset = queryset.filter(contest__participation__user=self.request.profile)
         else:
-            queryset = queryset.select_related('contest__participation__contest') \
-                .defer('contest__participation__contest__description')
+            queryset = queryset.select_related('contest_object').defer('contest_object__description')
 
             # This is not technically correct since contest organizers *should* see these, but
             # the join would be far too messy

--- a/judge/views/submission.py
+++ b/judge/views/submission.py
@@ -28,7 +28,7 @@ def submission_related(queryset):
     return queryset.select_related('user__user', 'problem', 'language') \
         .only('id', 'user__user__username', 'user__display_rank', 'user__rating', 'problem__name',
               'problem__code', 'problem__is_public', 'language__short_name', 'language__key', 'date', 'time', 'memory',
-              'points', 'result', 'status', 'case_points', 'case_total', 'current_testcase')
+              'points', 'result', 'status', 'case_points', 'case_total', 'current_testcase', 'contest_object')
 
 
 class SubmissionMixin(object):

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -24,10 +24,10 @@
     <div>
         {{ link_user(submission.user) }}
         <span class="time">{{ relative_time(submission.date) }}</span>
-        {% if not request.in_contest and submission.contest_or_none %}
-            <a href="{{ url('contest_view', submission.contest_or_none.participation.contest.key) }}"
+        {% if not request.in_contest and submission.contest_object_id %}
+            <a href="{{ url('contest_view', submission.contest_object.key) }}"
                class="submission-contest">
-                <i title="{{ submission.contest_or_none.participation.contest.name }}" class="fa fa-dot-circle-o"></i>
+                <i title="{{ submission.contest_object.name }}" class="fa fa-dot-circle-o"></i>
             </a>
         {% endif %}
     </div>

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -24,10 +24,10 @@
     <div>
         {{ link_user(submission.user) }}
         <span class="time">{{ relative_time(submission.date) }}</span>
-        {% if not request.in_contest and submission.contest_object_id %}
-            <a href="{{ url('contest_view', submission.contest_object.key) }}"
+        {% if not request.in_contest and submission.contest_key %}
+            <a href="{{ url('contest_view', submission.contest_key) }}"
                class="submission-contest">
-                <i title="{{ submission.contest_object.name }}" class="fa fa-dot-circle-o"></i>
+                <i title="{{ submission.contest_name }}" class="fa fa-dot-circle-o"></i>
             </a>
         {% endif %}
     </div>

--- a/templates/submission/row.html
+++ b/templates/submission/row.html
@@ -24,10 +24,10 @@
     <div>
         {{ link_user(submission.user) }}
         <span class="time">{{ relative_time(submission.date) }}</span>
-        {% if not request.in_contest and submission.contest_key %}
-            <a href="{{ url('contest_view', submission.contest_key) }}"
+        {% if not request.in_contest and submission.contest_object_id %}
+            <a href="{{ url('contest_view', submission.contest_object.key) }}"
                class="submission-contest">
-                <i title="{{ submission.contest_name }}" class="fa fa-dot-circle-o"></i>
+                <i title="{{ submission.contest_object.name }}" class="fa fa-dot-circle-o"></i>
             </a>
         {% endif %}
     </div>


### PR DESCRIPTION
An improved version of #1065 that does not use `F` objects. Those cause a very nasty bad query plan issue on MySQL when doing a `COUNT(*)` query without any other joins.