### PR TITLE
Serve problem generator file with generic content-type

### DIFF
--- a/judge/views/problem_data.py
+++ b/judge/views/problem_data.py
@@ -216,10 +216,7 @@ def problem_data_file(request, problem, path):
         except IOError:
             raise Http404()
 
-    type, encoding = mimetypes.guess_type(path)
-    response['Content-Type'] = type or 'application/octet-stream'
-    if encoding is not None:
-        response['Content-Encoding'] = encoding
+    response['Content-Type'] = 'application/octet-stream'
     return response
 
 


### PR DESCRIPTION
This fixes a possible security issue where a problem setter could upload a HTML generator file and have it served as actual HTML (XSS, etc.)

This should also be considered for #954 